### PR TITLE
fix: sorry, too many connections.

### DIFF
--- a/block/block_postgres.go
+++ b/block/block_postgres.go
@@ -13,6 +13,7 @@ func (repo *postgresBlockRepository) GetByPos(x, y, z int) (*Block, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 	if !rows.Next() {
 		return nil, nil
 	}

--- a/block/block_postgres_test.go
+++ b/block/block_postgres_test.go
@@ -16,3 +16,42 @@ func TestPostgresBlocksRepo(t *testing.T) {
 	blocks_repo := block.NewBlockRepository(db, types.DATABASE_POSTGRES)
 	testBlocksRepository(t, blocks_repo)
 }
+
+func TestMaxConnections(t *testing.T) {
+	db, err := getPostgresDB(t)
+	assert.NoError(t, err)
+
+	assert.NoError(t, block.MigrateBlockDB(db, types.DATABASE_POSTGRES))
+	blocks_repo := block.NewBlockRepository(db, types.DATABASE_POSTGRES)
+	assert.NotNil(t, blocks_repo)
+
+	var maxConnections int
+	row := db.QueryRow("show max_connections;")
+	err = row.Scan(&maxConnections)
+	assert.NoError(t, err)
+	t.Logf("Testing against %v max connections", maxConnections)
+
+	fakeBlock := block.Block{
+		PosX: 1,
+		PosY: 1,
+		PosZ: 1,
+		Data: []byte("test"),
+	}
+	if err := blocks_repo.Update(&fakeBlock); err != nil {
+		t.Fatalf("Error setting up test case: %v", err)
+	}
+
+	// Run more than max_connections query operations in a loop
+	count := 0
+	for i := 0; i < maxConnections*2; i++ {
+		b, err := blocks_repo.GetByPos(1, 1, 1)
+		count++
+		if b != nil && count%10 == 0 {
+			t.Logf("Executed %d operations. b=%v", count, b)
+		}
+		if err != nil {
+			t.Errorf("Unexpected error after %d operations: %v", count, err)
+			break
+		}
+	}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
    - PGPORT=5432
    - LOGLEVEL=debug
   working_dir: /data
-  command: ["go", "test", "./...", "-cover"]
+  command: ["go", "test", "./...", "-v", "-cover"]
 
 volumes:
   postgres: {}


### PR DESCRIPTION
database/Sql.Rows.Close() should be called as it is a safe to call and idempotent; not calling it will keep the underlying connection open.

Added an integration test to reproduce the issue
and a fix to it.

Fixes #53